### PR TITLE
Replace colon by comma

### DIFF
--- a/reference.c
+++ b/reference.c
@@ -118,7 +118,7 @@ int RefQuery(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                  "%s%s", prefix, list_values[i]);
     }
 
-    query_result = rconcat_results(ctx, keys, list_len, ':');
+    query_result = rconcat_results(ctx, keys, list_len, ',');
 
     for (i = 0; i < list_len; i++) {
         free(keys[i]);

--- a/reference.c
+++ b/reference.c
@@ -65,7 +65,7 @@ char* rconcat_results(RedisModuleCtx *ctx, char **results, int len, char sep) {
         for (j = 0; j < strlen(current); j++, p++) {
             final[p] = current[j];
         }
-        final[p++] = ':';
+        final[p++] = sep;
     }
 
     final[total_size] = '\0';


### PR DESCRIPTION
Replacing separator from ":" to "," as stated in `README.md` (line 48)